### PR TITLE
Update 000-default.conf

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -6,7 +6,7 @@
         # match this virtual host. For the default virtual host (this file) this
         # value is not decisive as it is used as a last resort host regardless.
         # However, you must set it for any further virtual host explicitly.
-        #ServerName www.example.com
+        ServerName localhost
 
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html


### PR DESCRIPTION
get rid of "AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.18.0.4. Set the 'ServerName' directive globally to suppress this message" error in logs