### PR TITLE
Trailing semicolon

### DIFF
--- a/html/js/config.js
+++ b/html/js/config.js
@@ -4,5 +4,5 @@ var findAPIConfig = {
 }
 
 var dataLoaderConfig = {
-	dataLoaderAPI: location.protocol+"//"+location.host+"/quip-loader/submitData",
+	dataLoaderAPI: location.protocol+"//"+location.host+"/quip-loader/submitData"
 }


### PR DESCRIPTION
Removed trailing semicolon after `dataLoaderAPI` value, since there's nothing following it.