### PR TITLE
relative path fix

### DIFF
--- a/html/FlexTables/config.json
+++ b/html/FlexTables/config.json
@@ -14,7 +14,7 @@
         "name": "tissueId",
         "value": "case_id"
       }],
-      "url": "camicroscope/osdCamicroscope.php"
+      "url": "../camicroscope/osdCamicroscope.php"
     }
   ]
 }


### PR DESCRIPTION
camicroscope path is up one from flex tables. The previous hotfix did not work as intended. Awaiting review.