### PR TITLE
Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ COPY html/FlexTables/ /var/www/html/FlexTables/
 COPY html/featurescapeapps/ /var/www/html/featurescapeapps/
 
 # Tile Overlay Directory
-RUN mkdir /data/images/overlays/
+#RUN mkdir -p /data/images/overlays/
 
 CMD ["sh", "/root/run.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ COPY html/FlexTables/ /var/www/html/FlexTables/
 COPY html/featurescapeapps/ /var/www/html/featurescapeapps/
 
 # Tile Overlay Directory
-RUN mkdir -p /data/images/overlays/
+RUN mkdir /data/images/overlays/
 
 CMD ["sh", "/root/run.sh"]
 

--- a/run.sh
+++ b/run.sh
@@ -13,8 +13,10 @@ sed -i -e "s/Camicroscope_Annotations/Camicroscope_Annotations_comp/g"  /var/www
 sed -i -e "s/Camicroscope_DataLoader/Camicroscope_DataLoader_comp/g"  /var/www/html2/FlexTables/config.json
 sed -i -e "s/default_db: 'quip'/default_db: 'quip_comp'/g"  /var/www/html2/featurescapeapps/js/config.js
 # -- end of new version -------
-# tile overlay symlink
-ln -s /data/images/overlays /var/www/html/overlays
+
+# Tile Overlay Directory and Symlink
+mkdir -p /data/images/overlays/ && ln -s /data/images/overlays /var/www/html/overlays
+
 rm -f /var/run/apache2.pid
 service apache2 start
 sed '/Listen 80/a Listen 8080' /etc/apache2/ports.conf


### PR DESCRIPTION
This change needs to happen because the /data/images/overlays directory was no longer being created in the file system.  When the overlays directory does not get created, the symlink gets created, but is broken.